### PR TITLE
Fix erroneous A/À capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Marcel is a french wrapper around the docker CLI, intended as a drop-in replacem
 
 ## Dockerfile
 
-Obviously, the ``Dockerfile`` name is not sovereign enough for us. That's why instead of ``Dockerfile``s, marcel uses ``RecetteAMarcel`` files.
+Obviously, the ``Dockerfile`` name is not sovereign enough for us. That's why instead of ``Dockerfile``s, marcel uses ``RecetteÀMarcel`` files.
 For now, they use the exact same syntax as ``Dockerfile``, but we'll see about that.
 
-For it to work, you just need to include a ``RecetteAMarcel`` file in the current directory where you execute your ``marcel construis`` command, are you're good to go.
+For it to work, you just need to include a ``RecetteÀMarcel`` file in the current directory where you execute your ``marcel construis`` command, are you're good to go.
 
 ## Thanks
 The [original idea](https://github.com/docker/docker/issues/19396) came of [@ndeloof](https://github.com/ndeloof)'s mind.

--- a/marcel.py
+++ b/marcel.py
@@ -45,15 +45,15 @@ TRANSLATIONS = {
 
 
 def check_for_marcefile(command):
-    """
+    u"""
     Detect if a RecettesÀMarcel file is present in the current directory.
     If so, inject a "-f ./RecettesÀMarcel" argument in the docker build command,
     if such an argument was not already passed.
     """
-    if exists(join(dirname(__file__), 'RecetteÀMarcel')):
+    if exists(join(dirname(__file__), u'RecetteÀMarcel')):
         # Check if a "-f" argument was not already given
         if '-f' not in command:
-            command = command[:2] + ['-f', './RecetteÀMarcel'] + command[2:]
+            command = command[:2] + ['-f', u'./RecetteÀMarcel'] + command[2:]
     return command
 
 

--- a/marcel.py
+++ b/marcel.py
@@ -46,14 +46,14 @@ TRANSLATIONS = {
 
 def check_for_marcefile(command):
     """
-    Detect if a RecettesAMarcel file is present in the current directory.
-    If so, inject a "-f ./RecettesAMarcel" argument in the docker build command,
+    Detect if a RecettesÀMarcel file is present in the current directory.
+    If so, inject a "-f ./RecettesÀMarcel" argument in the docker build command,
     if such an argument was not already passed.
     """
-    if exists(join(dirname(__file__), 'RecetteAMarcel')):
+    if exists(join(dirname(__file__), 'RecetteÀMarcel')):
         # Check if a "-f" argument was not already given
         if '-f' not in command:
-            command = command[:2] + ['-f', './RecetteAMarcel'] + command[2:]
+            command = command[:2] + ['-f', './RecetteÀMarcel'] + command[2:]
     return command
 
 


### PR DESCRIPTION
This fixes erroneous `RecetteAMarcel` to have something correct: `RecetteÀMarcel` to match Acamédie Française specification, as documented in [1]. A tutorial can also be found on Wikipédia [2].

[1] http://www.academie-francaise.fr/la-langue-francaise/questions-de-langue#5_strong-em-accentuation-des-majuscules-em-strong
[2] https://fr.wikipedia.org/wiki/Usage_des_majuscules_en_fran%C3%A7ais