### PR TITLE
Ajoute 'fait' pour remplacer le barbarisme 'exec'

### DIFF
--- a/marcel.py
+++ b/marcel.py
@@ -14,6 +14,7 @@ __version__ = '0.1.0'
 TRANSLATIONS = {
     # Commands
     u'chauffe': u'run',
+    u'fait': u'exec',
     u'pousse': u'push',
     u'apporte': u'pull',
     u'bûches': u'logs',


### PR DESCRIPTION
Ce commit permet la déchéance d'exec, afin de pouvoir exécuter un processus souverainement dans un conteneur existant sans utiliser de barbarisme inutile.