### PR TITLE
Ajout de la completion automatique pour bash

### DIFF
--- a/LISEZ-MOI.md
+++ b/LISEZ-MOI.md
@@ -21,6 +21,12 @@ Pour des raisons évidentes, ``Dockerfile`` ne nous semble pas assez souverain, 
 
 Pour que cela fonctionne, il vous suffit d'intégrer le fichier ``RecetteÀMarcel`` dans votre dossier courant où vous exécuterez ensuite ``marcel bricole``. Et voilà, vous pouvez travailler !
 
+## Auto-complétion avec bash
+Ajoutez dans votre ``~/.bashrc`` :
+```bash
+source <(marcel complète bash)
+```
+
 ## Comment contribuer ?
 
 Pour commencer, merci de contribuer à la splendeur de la « french tech ». Vous aurez besoin pour cela d'installer les dépendances dans votre environnement virtuel:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ Marcel is a french wrapper around the docker CLI, intended as a drop-in replacem
 Obviously, the ``Dockerfile`` name is not sovereign enough for us. That's why instead of ``Dockerfile``s, marcel uses ``RecetteÀMarcel`` files.
 For now, they use the exact same syntax as ``Dockerfile``, but we'll see about that.
 
-For it to work, you just need to include a ``RecetteÀMarcel`` file in the current directory where you execute your ``marcel construis`` command, are you're good to go.
+For it to work, you just need to include a ``RecetteÀMarcel`` file in the current directory where you execute your ``marcel bricole`` command, are you're good to go.
+
+## Bash completion
+
+Add this line to your ``~/.bashrc``:
+```bash
+source <(marcel complète bash)
+```
 
 ## Contributing.
 

--- a/marcel.py
+++ b/marcel.py
@@ -77,6 +77,23 @@ MARCELFILE_TRANSLATIONS = {
 }
 
 
+def output_completion(shell):
+    if shell == 'bash':
+        print("""
+function _marcel_complete {
+    res=(${COMP_LINE:0:$COMP_POINT})
+    res=${res[-1]}
+    ary=(""" + ' '.join(TRANSLATIONS) + """)
+    for cmd in ${ary[*]}
+    do if [[ $cmd == $res* && $cmd != $res ]]; then COMPREPLY="$cmd $COMPREPLY"; fi
+    done
+    COMPREPLY=($(echo -e "${COMPREPLY}" | sed -e 's/[[:space:]]*$//'))
+}
+
+complete -F _marcel_complete marcel
+""")
+
+
 def translate_marcelfile(marcelfile):
     """
     Converts a RecetteÀMarcel to a Dockerfile
@@ -144,6 +161,9 @@ def build_command(command):
 
 
 def main():  # pragma: no cover
+    if len(sys.argv) > 2 and sys.argv[1] == "complète":
+        output_completion(sys.argv[2])
+        return
     """Run docker commands from marcel syntax."""
     subprocess.call(build_command(sys.argv))
 


### PR DESCRIPTION
Petite pr pour permettre a marcel d'avoir un minimum d'auto-complétion (sur bash) 
Pour l'activer rien de plus simple, il suffit d'ajouter 
```
source <(marcel complète bash)
```
dans votre `~/.bashrc`

Je pense que le mieux serait de rappeler marcel depuis la fonction de complétion afin de générer ça en python